### PR TITLE
🔒️ Split Gradle CI

### DIFF
--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -1,0 +1,34 @@
+name: Copilot Setup Steps
+
+on:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yaml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yaml
+
+jobs:
+  copilot-setup-steps:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: latest
+      - run: pnpm install

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -2,13 +2,13 @@ name: GitHub Pages
 
 on:
   push:
-    branches: main
+    branches:
+      - main
 
 jobs:
   build_pages:
-    runs-on: ubuntu-latest
-
     if: github.actor != 'nektos/act'
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -25,17 +25,16 @@ jobs:
           path: build/docs/javadoc
 
   deploy_pages:
-    needs: build_pages
-
     permissions:
       pages: write
       id-token: write
 
+    needs: build_pages
+    runs-on: ubuntu-latest
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/deploy-pages@v4

--- a/.github/workflows/gradle-publish.yaml
+++ b/.github/workflows/gradle-publish.yaml
@@ -1,0 +1,62 @@
+name: Java Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v5
+
+      - run: ./gradlew build
+
+      - uses: actions/upload-artifact@v7
+        if: github.actor != 'nektos/act'
+        with:
+          name: switcheroo
+          path: build/libs
+          compression-level: 9
+          if-no-files-found: error
+
+  publish:
+    permissions:
+      contents: write
+      packages: write
+
+    needs: build
+    if: github.actor != 'nektos/act'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v5
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: switcheroo
+          path: build/libs
+
+      - run: gh release create ${{ github.ref_name }} --generate-notes --title ${{ github.ref_name }} --verify-tag build/libs/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: ./gradlew publish
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -1,19 +1,23 @@
 name: Java CI
 
 on:
-  push:
-    branches: main
-    tags: v*
+  merge_group:
+    branches:
+      - main
   pull_request:
-    branches: main
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  test:
     permissions:
-      contents: write
-      packages: write
+      contents: read
+
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -26,22 +30,11 @@ jobs:
       - run: ./gradlew build
       - run: ./gradlew spotlessCheck
       - run: ./gradlew javadoc
-        if: github.ref_type != 'tag'
 
       - uses: actions/upload-artifact@v7
-        if: github.ref_name == 'main' && github.actor != 'nektos/act'
+        if: github.actor != 'nektos/act'
         with:
           name: switcheroo
           path: build/libs
+          compression-level: 9
           if-no-files-found: error
-
-      - run: gh release create ${{ github.ref_name }} --generate-notes --title ${{ github.ref_name }} --verify-tag build/libs/*
-        if: github.ref_type == 'tag' && github.actor != 'nektos/act'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: ./gradlew publish
-        if: github.ref_type == 'tag' && github.actor != 'nektos/act'
-        env:
-          GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
 	],
 	"repository": "github:NatoBoram/switcheroo",
 	"scripts": {
-		"build": "gradle build",
+		"build": "./gradlew build",
 		"clean": "rm -rf .classpath .factorypath .gradle .project .settings .vscode/launch.json bin build minecraft node_modules remappedSrc switcheroo_client.launch switcheroo_server.launch",
-		"dev": "gradle runClient",
-		"docs": "gradle javadoc",
-		"format": "prettier --write . && gradle spotlessApply",
-		"postinstall": "gradle downloadAssets && gradle genSources && gradle eclipse && gradle vscode",
-		"lint": "gradle spotlessCheck"
+		"dev": "./gradlew runClient",
+		"docs": "./gradlew javadoc",
+		"format": "prettier --write . && ./gradlew spotlessApply",
+		"postinstall": "./gradlew downloadAssets && ./gradlew genSources && ./gradlew eclipse && ./gradlew vscode",
+		"lint": "./gradlew spotlessCheck"
 	},
 	"devDependencies": {
 		"@prettier/plugin-xml": "^3.4.1",


### PR DESCRIPTION
<!-- Replace this by a short description under 60 characters -->

### 📝 Description

<!-- Why this pull request? -->

I wanted to have different permissions for the CI steps that publish vs build.

<!-- Why is this the best solution? -->

<!-- What you did -->

### 📓 References

<!-- A list of links to discussions, documentation, issues, pull requests -->

### 📸 Screenshots

<!-- Show us your work :D -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Separate Gradle CI to restrict publish permissions

### Added

- ✨ Add `copilot-setup-steps.yaml` workflow for dependency setup
- ✨ Add `gradle-publish.yaml` workflow with isolated `publish` job

### Changed

- 🔒️ Split `gradle.yaml`: rename `build` job to `test` and set `permissions: contents: read`
- 🔒️ Remove release/publish steps from `gradle.yaml`; publishing moved to `gradle-publish.yaml` (tag-triggered)
- 🔒️ Migrate `gradle.yaml` triggers to `merge_group`, `pull_request`, `push`, and `workflow_dispatch` on `main`
- 🔧 Restructure `github-pages.yaml` jobs to explicitly set `needs` and `runs-on`
- 🔨 Replace system `gradle` invocations with `./gradlew` in `package.json` scripts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->